### PR TITLE
Adds support to send custom headers though email connector

### DIFF
--- a/components/org.wso2.carbon.transport.email/src/main/java/org/wso2/transport/email/client/connector/EmailClientConnectorImpl.java
+++ b/components/org.wso2.carbon.transport.email/src/main/java/org/wso2/transport/email/client/connector/EmailClientConnectorImpl.java
@@ -350,6 +350,12 @@ public class EmailClientConnectorImpl implements EmailClientConnector {
                 message.setHeader(Constants.MAIL_HEADER_REFERENCES,
                         emailMessage.getHeader(Constants.MAIL_HEADER_REFERENCES));
             }
+            // Custom headers are handled below
+            for (Map.Entry<String, String> entry : emailMessage.getHeaders().entrySet()) {
+                if (entry.getKey().startsWith(Constants.MAIL_CUSTOM_HEADER_IDENTIFIER)) {
+                    message.setHeader(entry.getKey().split(Constants.CUSTOM_HEADER_DELIMITER)[1], entry.getValue());
+                }
+            }
         } catch (MessagingException e) {
             throw new EmailConnectorException(
                     "Error occurred while creating the email " + "using given carbon message. " + e.getMessage(), e);

--- a/components/org.wso2.carbon.transport.email/src/main/java/org/wso2/transport/email/utils/Constants.java
+++ b/components/org.wso2.carbon.transport.email/src/main/java/org/wso2/transport/email/utils/Constants.java
@@ -23,6 +23,9 @@ package org.wso2.transport.email.utils;
  */
 public class Constants {
 
+    public static final String MAIL_CUSTOM_HEADER_IDENTIFIER = "customHeader_";
+    public static final String CUSTOM_HEADER_DELIMITER = "_";
+
     private Constants(){};
     /**
      * Email server Connector property

--- a/components/org.wso2.carbon.transport.email/src/test/java/org/wso2/transport/email/client/connector/SmtpServerMailTestCase.java
+++ b/components/org.wso2.carbon.transport.email/src/test/java/org/wso2/transport/email/client/connector/SmtpServerMailTestCase.java
@@ -225,6 +225,31 @@ public class SmtpServerMailTestCase {
         Assert.assertEquals(messages.length, 3);
     }
 
+    @Test(description = "Test case to send emails via smtp server with custom headers set.")
+    public void sendingWithCustomHeaders()
+            throws  MessagingException, InterruptedException,
+                   EmailConnectorException {
+
+        // create user on mail server
+        mailServer.setUser(ADDRESS, USERNAME, PASSWORD);
+        EmailConnectorFactory connectorFactory = new EmailConnectorFactoryImpl();
+        EmailClientConnector clientConnector = connectorFactory.createEmailClientConnector();
+        clientConnector.init(initProperties);
+
+        EmailBaseMessage emailMessage = createEmailTextMessage("This is test message",
+                                                                "text/plain", "This is test message",
+                                                               "to1@localhost", null, null);
+        Map<String, String> customHeaders = new HashMap<>();
+        customHeaders.put("customHeader_email-header-name", "custom-email-header-value");
+        emailMessage.setHeaders(customHeaders);
+        clientConnector.send(emailMessage);
+        Thread.sleep(1000);
+        MimeMessage[] messages = mailServer.getReceivedMessages();
+        Assert.assertEquals(messages.length, 1);
+        Assert.assertEquals(messages[0].getHeader("email-header-name").length, 1);
+        Assert.assertEquals(messages[0].getHeader("email-header-name")[0], "custom-email-header-value");
+    }
+
 
     /**
      * Method implemented to create a email text message with relevant headers and properties.


### PR DESCRIPTION
## Purpose
Adds support to send custom headers though email connector. Users can pass custom headers though headers map in EmailBaseMessage which will be populated in the out going email as headers

## Approach
Introduced a convention to as custom headers to header map in EmailBaseMessage so that we can handle them separately. Any header with name starting from 'customHeader_' will be treated as a customer header. Which ever follows the 'customHeader_' will be treated as the actual header name. 'customHeader_<actualHeaderName>'. '_' is used here as is not a valid character in header name and can be used to split actual name.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
